### PR TITLE
set up Travis for continuous integration and deployment to PyPI/Github 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,27 @@
+# Byte-compiled / optimized files
 __pycache__/
-build/
-*.pyc
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / Packaging
+*.egg-info
+*.eggs
+MANIFEST
+build
+dist
+
+# Unit test / coverage files
+.tox/*
+.cache/
+.coverage
+.coverage.*
+htmlcov/
+
+# OSX Finder
+.DS_Store
+
+# pyenv python configuration file
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: false
+language: python
+python:
+  - 2.7
+  - 3.5
+
+install: pip install tox-travis
+script: tox
+
+deploy:
+  # deploy to PyPI on tags
+  - provider: pypi
+    server: https://upload.pypi.org/legacy/
+    on:
+      repo: typesupply/extractor
+      tags: true
+      all_branches: true
+      python: 3.5
+    user: anthrotype
+    password:
+      secure: j80CZr2m3srL2ZiIyXGQNx/od1zywo4O7nXg8PX4qKDmPX2CdMZW8b5ZkGZWRrLN2g/Ssd6Qo0WRQTkniz6/SDiBj4x9CJWJ+UbzIsJyAEEgiqF76Tp/kz0HESzJROwfuo67PX3bafyGWvBjDA9cS6xyp2j4rklq6+swCkbDk7NLmFqUps8XE1x4LIJFiF/hkDXxBvjXkitCHA9Z5NPViURujYLyWJ2mRBkWwyRN9q8xkH1pzo4OLuoblxi3u1kWhfcnJmZ3EX24g47oRqCPnChYKk4aArcoGPiRVclB7Ma6zE/fBtjqeMmaDmQw0g6HBFKLhJBXDc4hn8DNP6oGAtPi1FkKuG84CV/KwGGJ4/sulyuZj+73uZ8Hkr9hhEQBcqwWsyrYdzvQPUf1hdgScmGFnhdqubOY5+XOTGq5Jk1NvPg6K+yI9e6FxfWCWOD8Hzv4kz/qsbZ6JIEzb0c7EFnnRQFsTNbtB9ChJJol5dZCP7g5eQ+mZZVzxQ/l4VpZT7hdkb0UjBrk+eIJRgQGOIFM435Ul9bwp1ALddvnhytx++daFtk1/+6cd3kDbaeF+cHNkCsshfQE1O2E+GbEI+Ddm24Sw6dd2g6RbH4bBLdElFhMDx82SxgfNx7Jtx9NhNzqnOP9Xx+1NRRN1RXkxz9DFrs/KbNJOzv+qRk5ZP0=
+    distributions: sdist bdist_wheel
+    skip_upload_docs: true
+  # also create a Github Release with current tag
+  - provider: releases
+    api_key:
+      secure: Zfco0lC1K1ME79opimESfTq2gjoj702MDcSwm+r/+3mQbJaRROsUQTxtWMYrZ/VplQ8xQCFwO0f5BFZGcaEA/EbGb9DwjcUOpX54hIC1K4tFTWius8U8AuEwrVfvNNtGZRCpvyNVtkijVEM0CgrR8uFWYP4ZPpYOmYTNJH8DCHUw/kEfjjJJr7UKO7sv+7AxvotqDKANb+KuytiIzL1Z+cfD1h3uU7oOqB8fKNlZpE1GBaz+yPExLrGrlgsMWCKFUZShyHOIAM/JybzubX0+h3oyRAZKsn/5wN7Rs6cKnNR33Im+vECiIFlNW3g+GkiXbAAXZQKnJ2W41ShiIbwrk7jkD8ckkEj6JVJznj24h1ZwQ76EbL5YNAjAkFxeWFCfxHaL8z0h3wqoU/FLT6VPQoy1KFC3Vfne8l1n18rOVbWHHuS4xPvvjvl1k3itxh89pVUFR3wAgrcRAcyiNgpDHlS5+TsCz2h0cRSqRKP/PMwtztlQYdZChgUgH8mJIbLUQu5w1syWPGd4360q2OECmM3Xt/wFiCSH59DyZ2GPkSDEZMBzryRkLXliiKHZ2EUwI8kIwbrROCKRjPcUMQW64DX3HenrCBfNwHQ3756bg7ShtaylFvbls8sDFM/BNC406ok65OMW8db+xmQqJFqo0mU2hqRG3S0dP8k4Rst8l54=
+    on:
+      repo: typesupply/extractor
+      tags: true
+      all_branches: true
+      python: 3.5

--- a/Lib/extractor/__init__.py
+++ b/Lib/extractor/__init__.py
@@ -4,6 +4,9 @@ from extractor.formats.woff import isWOFF, extractFontFromWOFF
 from extractor.formats.type1 import isType1, extractFontFromType1
 from extractor.formats.ttx import isTTX, extractFontFromTTX
 
+
+__version__ = "0.2.0.dev0"
+
 _extractFunctions = dict(
     OTF=extractFontFromOpenType,
     Type1=extractFontFromType1,

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include License.txt
+
+include tox.ini
+include requirements.txt
+
+recursive-include tests *.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fonttools==3.3.1
+ufoLib==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,50 @@
+[bumpversion]
+current_version = 0.2.0.dev0
+commit = True
+tag = False
+tag_name = v{new_version}
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?
+serialize = 
+	{major}.{minor}.{patch}.{release}{dev}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = final
+values = 
+	dev
+	final
+
+[bumpversion:part:dev]
+
+[bumpversion:file:Lib/extractor/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"
+
+[wheel]
+universal = 1
+
+[sdist]
+formats = zip
+
+[aliases]
+test = pytest
+
+[metadata]
+license_file = License.txt
+
+[tool:pytest]
+minversion = 2.8
+testpaths = 
+	tests
+python_files = 
+	*_test.py
+python_classes = 
+	*Test
+addopts = 
+	-v
+	-r a
+

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,52 @@
 #!/usr/bin/env python
 
 import sys
-from setuptools import setup
-
-try:
-    import fontTools
-except:
-    print("*** Warning: extractor requires FontTools, see:")
-    print("    github.com/behdad/fonttools")
+from setuptools import setup, find_packages
 
 
-setup(name="extractor",
-    version="0.1",
+needs_pytest = {'pytest', 'test'}.intersection(sys.argv)
+pytest_runner = ['pytest_runner'] if needs_pytest else []
+needs_wheel = {'bdist_wheel'}.intersection(sys.argv)
+wheel = ['wheel'] if needs_wheel else []
+
+# TODO: add README.rst, so we can use on both Github and PyPI
+# with open('README.rst', 'r') as f:
+#     long_description = f.read()
+
+setup(
+    name="ufo_extractor",
+    version="0.2.0.dev0",
     description="Tools for extracting data from font binaries into UFO objects.",
+    # long_description=long_description,
     author="Tal Leming",
     author_email="tal@typesupply.com",
-    url="http://code.typesupply.com",
+    url="https://github.com/typesupply/extractor",
     license="MIT",
-    packages=[
-        "extractor",
-        "extractor.formats"
+    package_dir={"": "Lib"},
+    packages=find_packages("Lib"),
+    setup_requires=pytest_runner + wheel,
+    tests_require=[
+        'pytest>=2.8',
     ],
-    package_dir={"":"Lib"}
+    install_requires=[
+        "fonttools>=3.3.1",
+        "ufoLib>=2.0.0",
+    ],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Environment :: Other Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python",
+        "Topic :: Multimedia :: Graphics :: Editors :: Vector-Based",
+        "Topic :: Multimedia :: Graphics :: Graphics Conversion",
+        "Topic :: Multimedia :: Graphics",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Text Processing :: Fonts",
+    ],
 )

--- a/tests/extractor_test.py
+++ b/tests/extractor_test.py
@@ -1,0 +1,13 @@
+import extractor
+import unittest
+
+
+class ExtractUfoTest(unittest.TestCase):
+
+    # TODO: replace this with real test cases
+    def test_extractUFO_dummy_test(self):
+        self.assertTrue(True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py35
+
+[testenv]
+deps =
+    pytest
+    -rrequirements.txt
+commands =
+    pytest {posargs}


### PR DESCRIPTION
hey Tal,

we need to publish extractor on the python package index, similar to what we did for ufoLib, defcon, fontMath etc. (extractor is required by TruFont, among others).

The problem is that the package name "extractor" is already taken by some old bindings for GNU Libextractor, so I had to find an alternative name, "ufo-extractor" (doesn't matter hyphen or underscore, as pip normalizes them anyway).

Note that this is only the name as it shows on the index, not the package import name, which of course we don't want to change.

In order for this to work, you need to log in your Travis CI account and enable the extractor repository from there.

Then we can merge this PR and make a v0.2.0 tag, which will be uploaded automatically to PyPI. I'll take care of that. I just need you to enable Travis on the repo.

Thanks